### PR TITLE
Add: Reference issue number if not Closing Issue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,6 @@
 - [ ] None of my changes are plagiarized from another source without proper attribution.
 - [ ] My article does not contain shortened URLs or affiliate links.
 
-If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.
+If your pull request closes a GitHub issue, replace the XXXXX below with the issue number. If it does not fully close the Github issue, please only reference the issue number your pull request applies to, and remove "Closes #XXXXX"
 
 Closes #XXXXX


### PR DESCRIPTION
Added text to clarify that if the pull request does not close the issue, only add that it references it. Issues closing prematurely is a problem that I have seen come up multiple times in my short time here, hopefully this might help a bit.



<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] None of my changes are plagiarized from another source without proper attribution.
- [x] My article does not contain shortened URLs or affiliate links.

If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.

Closes #XXXXX
